### PR TITLE
Loosen lib3mf-python pin to >=2.3.2,<3 to unblock linux-aarch64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -27,7 +27,7 @@ requirements:
     - anytree >=2.8.0,<3
     - ezdxf >1.1.0,<2
     - ipython =8
-    - lib3mf-python =2.3.2
+    - lib3mf-python >=2.3.2,<3
     - numpy
     - ocp >=7.8,<7.9
     - ocpsvg >=0.4


### PR DESCRIPTION
## Motivation

`lib3mf-python =2.3.2` (exact pin) blocks installation on `linux-aarch64`
because `lib3mf 2.3.x` was never built for that architecture.
`conda-forge/lib3mf-feedstock#21` (merged 2026-05-05) added `linux-aarch64`
support, but only for `lib3mf 2.4.1` — the current stable release.

## Change

- `lib3mf-python =2.3.2` → `lib3mf-python >=2.3.2,<3`
- build number 0 → 1

## Why this is safe

- The upstream `pyproject.toml` already specifies `lib3mf >= 2.3.1` with no
  upper bound — no API break between 2.3.x and 2.4.x from the upstream author's
  perspective.
- `Lib3MF.Wrapper()` is called without arguments since
  `conda-forge/lib3mf-feedstock#19`, so wrapper construction is not
  version-sensitive.
- `lib3mf-python` is `noarch: python`; the only arch-sensitive part is the
  `lib3mf` C++ runtime it links against, which is now available for all
  platforms in 2.4.x.

## Result

Enables `build123d` (and downstream environments) on `linux-aarch64` hosts.